### PR TITLE
Fix for 'function already exists' error

### DIFF
--- a/plugin/phpns.vim
+++ b/plugin/phpns.vim
@@ -145,14 +145,14 @@ function! PhpExpandClass()
     call search('\([[:blank:]]*[[:alnum:]\\]\)*', 'ceW')
 endfunction
 
-function s:searchCapture(pattern, nr)
+function! s:searchCapture(pattern, nr)
     let s:capture = 0
     let str = join(getline(0, line('$')),"\n")
     call substitute(str, a:pattern, '\=[submatch(0), s:saveCapture(submatch('.a:nr.'))][0]', 'e')
     return s:capture
 endfunction
 
-function s:saveCapture(capture)
+function! s:saveCapture(capture)
     let s:capture = a:capture
 endfunction
 


### PR DESCRIPTION
Added !'s to the func definitions.

I mistook the following error for a plugin conflict, but it happens when the script gets re-sourced by Vundle after running :BundleInstall!

> Error detected while processing /Volumes/Storage/Dropbox/dev/vim/bundle/vim-php-namespace/plugin/phpns.vim:
> E122: Function 74_searchCapture already exists, add ! to replace it
> E122: Function 74_saveCapture already exists, add ! to replace it
