### PR TITLE
fixed namespace on first line (<?php)

### DIFF
--- a/plugin/phpns.vim
+++ b/plugin/phpns.vim
@@ -57,7 +57,7 @@ function! PhpFindFqcn(clazz)
         endtry
         1
         if search('^\s*\%(\%(abstract\|final\)\_s\+\)*\%(class\|interface\|trait\)\_s\+' . a:clazz . '\>') > 0
-            if search('^\s*namespace\s\+', 'be') > 0
+            if search('^\%(<?\%(php\s\+\)\?\)\?\s*namespace\s\+', 'be') > 0
                 let start = col('.')
                 call search('\([[:blank:]]*[[:alnum:]\\]\)*', 'ce')
                 let end = col('.')


### PR DESCRIPTION
only namespace on its own line would be found, but an accepted practice is to declare the namespace on the same line as the opening <?php (or <?) tag.
So I fixed it so that it will work as it previously did and also allow <?php namespace all on one line.
