### PR TITLE
Allow importing from root namespace

### DIFF
--- a/plugin/phpns.vim
+++ b/plugin/phpns.vim
@@ -64,7 +64,7 @@ function! PhpFindFqcn(clazz)
                 let ns = strpart(getline(line('.')), start, end-start)
                 return ns . "\\" . a:clazz
             else
-                throw "Namespace definition for " . a:clazz . " not found!"
+                return a:clazz
             endif
         else
             throw a:clazz . ": class not found!"


### PR DESCRIPTION
If namespace is not found, the class is in the root namespace. Just import this class from that root namespace rather than throwing an error.

This is especially useful for importing Laravel facades.

I ran tests and they still pass.
