### PR TITLE
README.markdown: fixes tag file example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -101,7 +101,7 @@ To keep updates fast, AutoTags won't operate if the tags file exceeds 7MB. To av
 Do not forget to load both files in vim:
 
     " ~/.vimrc
-    set tags+=./tags.vendors,tags.vendors
+    set tags+=tags,tags.vendors
 
 ### Key mappings
 


### PR DESCRIPTION
Thanks a lot for this plugin @arnaud-lb. It is awesome ! It fixes what is IMO one of the most annoying things in PHP, especially when working with large dependencies that have long namespace paths.

I may be mistaken here, but I think this example from the README is a little off.

Thanks again !