### PR TITLE
Sort

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,6 +45,18 @@ Then, hitting `\e` in normal or insert mode will expand the class name to a full
 $this->getMock('RouterInterface<-- cursor here or on the name; hit \e now to expand the class name'
 ```
 
+### Sort existing use statements alphabetically
+
+If you do not know how to organize use statements, (or anything else, for that
+matter), the alphabetical order might be a sensible choice, because it makes
+finding what you are looking for easier, and reduces the risk for conflicts :
+if everyone adds new things at the same line, conflicts are guaranteed.
+
+This vim plugin defines a `PhpSortUse()` you may use in your mappings:
+
+    autocmd FileType php inoremap <Leader>s <Esc>:call PhpSortUse()<CR>
+    autocmd FileType php noremap <Leader>s :call PhpSortUse()<CR>
+
 ## Installation:
 
 ### Using [pathogen](https://github.com/tpope/vim-pathogen)

--- a/README.markdown
+++ b/README.markdown
@@ -94,17 +94,17 @@ The plugin makes use of tag files. If you don't already use a tag file you may c
 or
 
     ctags -R --PHP-kinds=+cf
-    
+
 #### Traits
-    
+
 ctags doesn't indexes [traits](http://php.net/traits) by default, you have to add a `--regex-php` option to index them:
 
     ctags -R --PHP-kinds=+cf --regex-php=/^[ \t]*trait[ \t]+([a-z0_9_]+)/\1/t,traits/i
-    
+
 Alternatively, create a `~/.ctags` file with the following contents:
 
     --regex-php=/^[ \t]*trait[ \t]+([a-z0_9_]+)/\1/t,traits/i
-    
+
 You could also use [this patched version of ctags](https://github.com/shawncplus/phpcomplete.vim/wiki/Patched-ctags)
 
 #### Automatically updating tags
@@ -115,7 +115,7 @@ To keep updates fast, AutoTags won't operate if the tags file exceeds 7MB. To av
 
     # dependencies tags file (index only the vendor directory, and save tags in ./tags.vendors)
     ctags -R --PHP-kinds=+cf -f tags.vendors vendor
-    
+
     # project tags file (index only src, and save tags in ./tags; AutoTags will update this one)
     ctags -R --PHP-kinds=+cf src
 

--- a/plugin/phpns.vim
+++ b/plugin/phpns.vim
@@ -156,3 +156,13 @@ function! s:saveCapture(capture)
     let s:capture = a:capture
 endfunction
 
+function! PhpSortUse()
+    let restorepos = line(".") . "normal!" . virtcol(".") . "|"
+     " insert after last use or namespace or <?php
+    if search('^use\_s\_[[:alnum:][:blank:]\\_]*;', 'be') > 0
+        execute "'{,'}-1sort"
+    else
+        throw "No use statements found."
+    endif
+    exe restorepos
+endfunction

--- a/tests/test-sort.in
+++ b/tests/test-sort.in
@@ -1,0 +1,17 @@
+
+Sort test 1
+
+STARTTEST
+:%d
+a<?php
+
+use Goo\Baz;
+use Foo\Bar;
+
+class Boo
+{
+}:call PhpSortUse()
+ax:w! test.out
+:qa!
+ENDTEST
+

--- a/tests/test-sort.ok
+++ b/tests/test-sort.ok
@@ -1,0 +1,8 @@
+<?php
+
+use Foo\Bar;
+use Goo\Baz;
+
+class Boo
+{
+}x


### PR DESCRIPTION
Fixes #5 


This is my very first piece of vimscript, so do not hesitate to comment if you see something you do not like, I'm here to learn :)

Checklist :

- [x] handle nominal case
- [x] write some docs

A setting may be added to automatically sort the statements, but I guess that will be another PR.

Edge cases I can think of and my solution does not handle (yet) :

```php
<?php
namespace Foo;

use Baz;
use Bar; // no newline after that
class FooBar
{
}
```

```php
<?php
namespace Foo;

use Baz;

use Bar;


class FooBar
{
}
```

```php
<?php
namespace Foo;

class FooBar
{
    use MyTrait;
}
```