### PR TITLE
Be consistent with the name of the plugin

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -60,7 +60,7 @@ This vim plugin defines a `PhpSortUse()` you may use in your mappings:
 On top of that, you may want to have the dependencies every time you insert one.
 To enable this feature, use the dedicated global option:
 
-    let g:php_namespaces_sort_after_insert = 1
+    let g:php_namespace_sort_after_insert = 1
 
 ## Installation:
 

--- a/plugin/phpns.vim
+++ b/plugin/phpns.vim
@@ -8,7 +8,7 @@
 
 let s:capture = 0
 
-let g:php_namespaces_sort_after_insert = get(g:, 'php_namespaces_sort_after_insert', 0)
+let g:php_namespace_sort_after_insert = get(g:, 'php_namespace_sort_after_insert', 0)
 
 function! PhpFindMatchingUse(clazz)
 
@@ -123,7 +123,7 @@ function! PhpInsertUse()
         else
             call append(1, use)
         endif
-        if g:php_namespaces_sort_after_insert
+        if g:php_namespace_sort_after_insert
             call PhpSortUse()
         endif
     catch /.*/

--- a/tests/test-sort-after-insert.in
+++ b/tests/test-sort-after-insert.in
@@ -10,7 +10,7 @@ namespace Something;
 use Abc\Def;
 use Foo\Baz;
 
-class Bar:let g:php_namespaces_sort_after_insert=1
+class Bar:let g:php_namespace_sort_after_insert=1
 :call PhpInsertUse()
 ax:w! test.out
 :qa!


### PR DESCRIPTION
There is no s in the name of the plugin