### PR TITLE
Adding option for expanding FQCN with leading backslash

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,6 +45,10 @@ Then, hitting `\e` in normal or insert mode will expand the class name to a full
 $this->getMock('RouterInterface<-- cursor here or on the name; hit \e now to expand the class name'
 ```
 
+By default, a leading backslash is omitted when expanding to a FQCN. To enable the addition of a leading backslash, use the dedicated global option:
+
+    let g:leading_backslash_on_fqcn_expand = 1
+
 ### Sort existing use statements alphabetically
 
 If you do not know how to organize use statements, (or anything else, for that

--- a/plugin/phpns.vim
+++ b/plugin/phpns.vim
@@ -9,6 +9,8 @@
 let s:capture = 0
 
 let g:php_namespace_sort_after_insert = get(g:, 'php_namespace_sort_after_insert', 0)
+let g:leading_backslash_on_fqcn_expand = get(g:, 'leading_backslash_on_fqcn_expand', 0)
+
 
 function! PhpFindMatchingUse(clazz)
 
@@ -144,6 +146,10 @@ function! PhpExpandClass()
     if fqcn is 0
         return
     endif
+    " add leading backslash if configured
+   	if g:leading_backslash_on_fqcn_expand
+		let fqcn = "\\".fqcn
+	endif
     substitute /\%#[[:alnum:]\\_]\+/\=fqcn/
     exe restorepos
     " move cursor after fqcn


### PR DESCRIPTION
I kinda like having a leading backspace when expanding to the FQCN.