### PR TITLE
Use class without namespace

### DIFF
--- a/plugin/phpns.vim
+++ b/plugin/phpns.vim
@@ -68,7 +68,7 @@ function! PhpFindFqn(name)
                 let ns = strpart(getline(line('.')), start, end-start)
                 return ['class', ns . "\\" . a:name]
             else
-                return a:name
+                return ['class', a:name]
             endif
         elseif search('^\s*function\_s\+' . a:name . '\>') > 0
             if search('^\%(<?\%(php\s\+\)\?\)\?\s*namespace\s\+', 'be') > 0

--- a/tests/test-class-without-ns.fixtures/a.php
+++ b/tests/test-class-without-ns.fixtures/a.php
@@ -1,0 +1,5 @@
+<?php
+
+class Foo {
+}
+

--- a/tests/test-class-without-ns.fixtures/tags
+++ b/tests/test-class-without-ns.fixtures/tags
@@ -1,0 +1,7 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.9~svn20110310	//
+Foo	test-class-without-ns.fixtures/a.php	/^class Foo {$/;"	c

--- a/tests/test-class-without-ns.in
+++ b/tests/test-class-without-ns.in
@@ -1,0 +1,12 @@
+
+Basic test 1
+
+STARTTEST
+:%d
+a<?php
+
+class Foo:call PhpInsertUse()
+ax:w! test.out
+:qa!
+ENDTEST
+

--- a/tests/test-class-without-ns.ok
+++ b/tests/test-class-without-ns.ok
@@ -1,0 +1,5 @@
+<?php
+
+use Foo;
+
+class Foox


### PR DESCRIPTION
Sometimes we want to use class or interface without namespace, like `ArrayAccess`, but it's not working now.
After this commit, it can work correctly.