### PR TITLE
Add support for phps classname constants

### DIFF
--- a/plugin/phpns.vim
+++ b/plugin/phpns.vim
@@ -34,6 +34,7 @@ function! PhpFindFqn(name)
     let restorepos = line(".") . "normal!" . virtcol(".") . "|"
     let loadedCount = 0
     let tags = []
+
     try
         let fqn = PhpFindMatchingUse(a:name)
         if fqn isnot 0
@@ -109,16 +110,17 @@ function! PhpInsertUse()
     exe "normal mz"
     " move to the first component
     " Foo\Bar => move to the F
-    call search('[[:alnum:]\\_]\+', 'bcW')
+    call search('[[:alnum:]\\:_]\+', 'bcW')
     let cur_name = expand("<cword>")
     try
-        let fqn = PhpFindMatchingUse(cur_name)
+        let search_phrase = substitute(cur_name, "::class", "", "")
+        let fqn = PhpFindMatchingUse(search_phrase)
         if fqn isnot 0
             exe "normal! `z"
-            echo "import for " . cur_name . " already exists"
+            echo "import for " . search_phrase . " already exists"
             return
         endif
-        let tfqn = PhpFindFqn(cur_name)
+        let tfqn = PhpFindFqn(search_phrase)
         if tfqn is 0
             echo "fully qualified class name was not found"
             return

--- a/tests/test-classname-constant.fixtures/a.php
+++ b/tests/test-classname-constant.fixtures/a.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Foo;
+
+class Bar {
+}
+

--- a/tests/test-classname-constant.fixtures/tags
+++ b/tests/test-classname-constant.fixtures/tags
@@ -1,0 +1,7 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.9~svn20110310	//
+Bar	test-classname-constant.fixtures/a.php	/^class Bar {$/;"	c

--- a/tests/test-classname-constant.in
+++ b/tests/test-classname-constant.in
@@ -1,0 +1,12 @@
+
+Basic test 1
+
+STARTTEST
+:%d
+a<?php
+
+Bar::class:call PhpInsertUse()
+ax:w! test.out
+:qa!
+ENDTEST
+

--- a/tests/test-classname-constant.ok
+++ b/tests/test-classname-constant.ok
@@ -1,0 +1,5 @@
+<?php
+
+use Foo\Bar;
+
+Bar::classx


### PR DESCRIPTION
Adds support for phps classname constant `Foo::class`